### PR TITLE
FIS-64-graphql-refactor (apollo client)

### DIFF
--- a/apps/client/app/dashboard/page.tsx
+++ b/apps/client/app/dashboard/page.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 
 function UserItem({ user }) {
 
-  const cycleId = "64e605dff9098d208418d435"
+  const cycleId = "64e46166c1903f7622ec9852"
 
 
   return (

--- a/apps/client/app/dashboard/page.tsx
+++ b/apps/client/app/dashboard/page.tsx
@@ -1,14 +1,16 @@
-'use client'
 import '../global.css'
 import Link from "next/link";
 import { Button } from '@/components/ui/button';
 import { useQuery } from '@apollo/client'
 import { GET_USERS } from '@/lib/queries';
+import { getClient } from '@/lib/client';
+
+export const fetchCache = 'force-no-store'
 
 function UserItem({ user }) {
 
 
-  const cycleId = "64e84ce566d3488fe1d4a8cf"
+  const cycleId = "64e881e98bca6cf04694cc9e"
 
 
   return (
@@ -22,15 +24,12 @@ function UserItem({ user }) {
   );
 }
 
-export default function Dashboard() {
+export default async function Dashboard() {
 
+  const client = getClient()
 
+  const { data: { getUsers: users } } = await client.query({ query: GET_USERS })
 
-
-  const { loading, error, data } = useQuery(GET_USERS)
-  if (loading) return 'Loading...';
-  if (error) return `Error! ${error.message}`;
-  const { getUsers: users } = data
 
   return (
     <div>

--- a/apps/client/app/dashboard/page.tsx
+++ b/apps/client/app/dashboard/page.tsx
@@ -1,7 +1,6 @@
 import '../global.css'
 import Link from "next/link";
 import { Button } from '@/components/ui/button';
-import { useQuery } from '@apollo/client'
 import { GET_USERS } from '@/lib/queries';
 import { getClient } from '@/lib/client';
 

--- a/apps/client/app/dashboard/page.tsx
+++ b/apps/client/app/dashboard/page.tsx
@@ -1,14 +1,14 @@
 'use client'
-import { useEffect, useState } from 'react'
-import axios from 'axios'
 import '../global.css'
 import Link from "next/link";
 import { Button } from '@/components/ui/button';
-
+import { useQuery } from '@apollo/client'
+import { GET_USERS } from '@/lib/queries';
 
 function UserItem({ user }) {
 
-  const cycleId = "64e46166c1903f7622ec9852"
+
+  const cycleId = "64e84ce566d3488fe1d4a8cf"
 
 
   return (
@@ -23,32 +23,14 @@ function UserItem({ user }) {
 }
 
 export default function Dashboard() {
-  const [users, setUsers] = useState([])
 
-  const getUsersQuery = `{
-    getUsers {
-      _id
-      fullName
-      title
-      teamName
-    }
-  }`
-  useEffect(() => {
-    async function getUsers() {
-      try {
-        const response = await axios.post('http://localhost:8080/graphql', {
-          query: getUsersQuery,
-        });
 
-        setUsers(response.data.data.getUsers)
-      } catch (error) {
-        console.error(error);
-      }
-    }
 
-    getUsers();
-  }, [getUsersQuery])
 
+  const { loading, error, data } = useQuery(GET_USERS)
+  if (loading) return 'Loading...';
+  if (error) return `Error! ${error.message}`;
+  const { getUsers: users } = data
 
   return (
     <div>

--- a/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
+++ b/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
@@ -44,9 +44,9 @@ async function getUser(params) {
   }
 }
 
-async function getFullReport(variables) {
-  console.log('variables console', variables)
 
+
+async function getFullReport(variables) {
   const query = `
       query GetReport($targetId: String!, $cycleId: String!) {
         getReport(targetId: $targetId, cycleId: $cycleId) {
@@ -54,15 +54,31 @@ async function getFullReport(variables) {
             target
             cycle
           }
-
           remarks
           status
-           reviews {
+          reviews {
             peer {
+              reviewer
+              isDeclined
+              submitted
               grades {
-                metric 
+                metric
+                rating
+                maxRating
+                comment
               }
             }
+            self {
+              reviewer
+              isDeclined
+              submitted
+              grades {
+                metric
+                rating
+                maxRating
+                comment
+              }
+            }         
            }
         }
       }`
@@ -91,12 +107,66 @@ async function Report({ params }) {
   const report = await getReport(variables)
   const fullReport = await getFullReport(variables)
 
-  console.log('full report console', fullReport)
-  console.log('paramsss console ------>', params)
+
+
+  const peerGrades = fullReport.reviews.peer.map(peerItem => {
+
+    const grades = peerItem.grades.map(metric => {
+      return metric.metric + ' : ' + metric.rating + ' / ' + metric.comment
+    });
+
+    return {
+      reviewer: peerItem.reviewer,
+      submitted: peerItem.submitted,
+      grades: grades
+
+    };
+  });
+
+
+
+
+
 
   return (
     <div>
-      {manager ? <div>Manager</div> : <div></div>}
+      {manager ?
+        <div>
+          <div>Manager</div>
+          <div>{fullReport.remarks}</div>
+          <h2>SELF REVIEW</h2>
+          <p>
+            {fullReport.reviews.self.grades[0].metric} :   {fullReport.reviews.self.grades[0].rating}
+          </p>
+          <p>
+            {fullReport.reviews.self.grades[1].metric} :   {fullReport.reviews.self.grades[1].rating}
+          </p>
+          <p>
+            {fullReport.reviews.self.grades[2].metric} :   {fullReport.reviews.self.grades[2].rating}
+          </p>
+
+          <h2>PEER REVIEW 1</h2>
+
+          {peerGrades.map((item, index) => (
+
+            <div className='grid grid-cols-2' key={index}>
+              <p>
+                {item.reviewer} : {item.grades[0]}
+              </p>
+              <p>
+                {item.reviewer} : {item.grades[1]}
+              </p>
+              <p>
+                {item.reviewer} : {item.grades[2]}
+              </p>
+            </div>
+          )
+          )}
+
+        </div>
+
+
+        : <div></div>}
       {/* // (!status ?{' '} */}
       {/* <p>come back later </p> : */}
       {/* <div className="p-12">

--- a/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
+++ b/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
@@ -34,7 +34,38 @@ async function getUser(params) {
   }
 }
 
+async function getFullReport(variables) {
+  console.log('variables console', variables)
+
+  const query = `
+      query GetReport($targetId: String!, $cycleId: String!) {
+        getReport(targetId: $targetId, cycleId: $cycleId) {
+          _id {
+            target
+            cycle
+          }
+          remarks
+          reviews{
+            peer
+            self
+          }
+        }
+      }`
+
+  try {
+    const response = await axios.post('http://localhost:8080/graphql', {
+      query,
+      variables,
+    })
+    return response.data.data.getReport
+  } catch (error) {
+    console.error(error)
+  }
+}
+
 async function Report({ params }) {
+  const manager = true
+
   const targetId = params.id
   const cycleId = params.cycleId
   const query = `
@@ -48,23 +79,31 @@ async function Report({ params }) {
         }
       }`
 
-
   // const status = undefined
   const variables = { targetId, cycleId }
 
-  const report = await getReport(query, variables)
   const user = await getUser(params)
+  const report = await getReport(query, variables)
+  const fullReport = await getFullReport(variables)
+
+
+  console.log('full report console',fullReport)
+  console.log('paramsss console ------>',params)
 
   return (
-    // (!status ? <p>come back later </p> :
-    <div className='p-12'>
-      <h1 className='text-2xl'>Your Report {user}</h1>
-      <div>
-        <p>Remarks:</p>
-        <p>{report.remarks}</p>
-      </div>
+    <div>
+      {manager ? <div>Manager</div> : <div></div>}
+      {/* // (!status ?{' '} */}
+      {/* <p>come back later </p> : */}
+      {/* <div className="p-12">
+        <h1 className="text-2xl">Your Report {user}</h1>
+        <div>
+          <p>Remarks:</p>
+          <p>{report.remarks}</p>
+        </div>
+      </div> */}
+      {/* // ) */}
     </div>
-    // )
   )
 }
 

--- a/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
+++ b/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
@@ -1,5 +1,15 @@
 import axios from 'axios'
 import '../../../../global.css'
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table"
+
 
 
 
@@ -153,44 +163,49 @@ async function Report({ params }) {
 
 
   return (
-    <div>
+    <div className='p-4'>
       {manager ?
         <div>
-          <div>Manager</div>
-          <div>{fullReport.remarks}</div>
+          <h1 className='text-2xl'>Manager</h1>
 
+          <h2>Report remarks: {fullReport.remarks}</h2>
 
-
-          <h2>Peer Reviews</h2>
-          {fullReport.reviews.peer.map((peerReview, index) => (
-            <div key={index}>
-              <div>
-                <strong>Reviewer:</strong> {peerReview.reviewer}
-              </div>
-              {peerReview.grades.map((grade, gradeIndex) => (
-                <div className='grid grid-cols-2 py-4 divide-y-2' key={gradeIndex}>
-                  <p>
-                    <strong>{grade.metric}:</strong> {grade.rating} / {grade.maxRating}
-                  </p>
-                  <p>{grade.comment}</p>
+          <Table className='pt-4' >
+            <TableCaption>All the metrics and reting from reviews</TableCaption>
+            <h2 className='font-bold' >Peer Reviews</h2>
+            <TableBody>
+              {fullReport.reviews.peer.map((peerReview, index) => (
+                <div key={index}>
+                  <TableRow>
+                    <TableCell className="font-medium">{peerReview.reviewer}</TableCell>
+                  </TableRow>
+                  {peerReview.grades.map((grade, gradeIndex) => (
+                    <div className='grid grid-cols-5' key={gradeIndex}>
+                      <TableCell>{grade.metric}</TableCell>
+                      <TableCell>{grade.rating}/{grade.maxRating}</TableCell>
+                      <TableCell className='grid col-span-3' >{grade.comment}</TableCell>
+                    </div>
+                  ))}
                 </div>
               ))}
-            </div>
-          ))}
-
-
-          <h2>Self Review</h2>
-          <div>
-            <strong>Reviewer:</strong> {fullReport.reviews.self.reviewer}
-          </div>
-          {fullReport.reviews.self.grades.map((grade, gradeIndex) => (
-            <div key={gradeIndex}>
-              <p>
-                <strong>{grade.metric}:</strong> {grade.rating} / {grade.maxRating}
-              </p>
-              <p>{grade.comment}</p>
-            </div>
-          ))}
+            </TableBody>
+          </Table>
+          <h2 className='font-bold'>Self Review</h2>
+          <Table >
+            <TableCaption>All the metrics and reting from reviews</TableCaption>
+            <TableBody>
+              <TableRow>
+                <TableCell className="font-medium">{fullReport.reviews.self.reviewer}</TableCell>
+              </TableRow>
+              {fullReport.reviews.self.grades.map((grade, gradeIndex) => (
+                <div className='grid grid-cols-5' key={gradeIndex}>
+                  <TableCell>{grade.metric}</TableCell>
+                  <TableCell>{grade.rating}/{grade.maxRating}</TableCell>
+                  <TableCell className='grid col-span-3' >{grade.comment}</TableCell>
+                </div>
+              ))}
+            </TableBody>
+          </Table>
         </div>
 
         : <div></div>

--- a/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
+++ b/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
@@ -1,6 +1,49 @@
 import axios from 'axios'
 import '../../../../global.css'
 
+
+
+// interface Grade {
+//   metric: string;
+//   rating: number;
+//   maxRating: number;
+//   comment: string;
+// }
+
+// interface Review {
+//   reviewer: string;
+//   isDeclined: boolean | null;
+//   submitted: boolean;
+//   grades: Grade[];
+// }
+
+// interface ReportData {
+//   data: {
+//     getReport: {
+//       _id: {
+//         target: string;
+//         cycle: string;
+//       };
+//       remarks: string;
+//       reviews: {
+//         peer: Review[];
+//         self: Review;
+//       };
+//     };
+//   };
+// }
+
+
+
+
+
+
+
+
+
+
+
+
 async function getReport(variables) {
   const query = `
   query GetReport($targetId: String!, $cycleId: String!) {
@@ -109,64 +152,49 @@ async function Report({ params }) {
 
 
 
-  const peerGrades = fullReport.reviews.peer.map(peerItem => {
-
-    const grades = peerItem.grades.map(metric => {
-      return metric.metric + ' : ' + metric.rating + ' / ' + metric.comment
-    });
-
-    return {
-      reviewer: peerItem.reviewer,
-      submitted: peerItem.submitted,
-      grades: grades
-
-    };
-  });
-
-
-
-
-
-
   return (
     <div>
       {manager ?
         <div>
           <div>Manager</div>
           <div>{fullReport.remarks}</div>
-          <h2>SELF REVIEW</h2>
-          <p>
-            {fullReport.reviews.self.grades[0].metric} :   {fullReport.reviews.self.grades[0].rating}
-          </p>
-          <p>
-            {fullReport.reviews.self.grades[1].metric} :   {fullReport.reviews.self.grades[1].rating}
-          </p>
-          <p>
-            {fullReport.reviews.self.grades[2].metric} :   {fullReport.reviews.self.grades[2].rating}
-          </p>
 
-          <h2>PEER REVIEW 1</h2>
 
-          {peerGrades.map((item, index) => (
 
-            <div className='grid grid-cols-2' key={index}>
-              <p>
-                {item.reviewer} : {item.grades[0]}
-              </p>
-              <p>
-                {item.reviewer} : {item.grades[1]}
-              </p>
-              <p>
-                {item.reviewer} : {item.grades[2]}
-              </p>
+          <h2>Peer Reviews</h2>
+          {fullReport.reviews.peer.map((peerReview, index) => (
+            <div key={index}>
+              <div>
+                <strong>Reviewer:</strong> {peerReview.reviewer}
+              </div>
+              {peerReview.grades.map((grade, gradeIndex) => (
+                <div className='grid grid-cols-2 py-4 divide-y-2' key={gradeIndex}>
+                  <p>
+                    <strong>{grade.metric}:</strong> {grade.rating} / {grade.maxRating}
+                  </p>
+                  <p>{grade.comment}</p>
+                </div>
+              ))}
             </div>
-          )
-          )}
+          ))}
 
+
+          <h2>Self Review</h2>
+          <div>
+            <strong>Reviewer:</strong> {fullReport.reviews.self.reviewer}
+          </div>
+          {fullReport.reviews.self.grades.map((grade, gradeIndex) => (
+            <div key={gradeIndex}>
+              <p>
+                <strong>{grade.metric}:</strong> {grade.rating} / {grade.maxRating}
+              </p>
+              <p>{grade.comment}</p>
+            </div>
+          ))}
         </div>
 
-
-        : <div></div>}
+        : <div></div>
+      }
       {/* // (!status ?{' '} */}
       {/* <p>come back later </p> : */}
       {/* <div className="p-12">
@@ -177,7 +205,7 @@ async function Report({ params }) {
         </div>
       </div> */}
       {/* // ) */}
-    </div>
+    </div >
   )
 }
 

--- a/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
+++ b/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
@@ -12,8 +12,6 @@ import { getClient } from '@/lib/client'
 import { GET_FULLREPORT, GET_USER_FULLNAME_BY_ID, GET_REPORT_FOR_EMPLOYEE } from '@/lib/queries'
 
 
-
-
 async function Report({ params }) {
   const client = getClient()
 

--- a/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
+++ b/apps/client/app/employee/[id]/report/[cycleId]/page.tsx
@@ -1,7 +1,17 @@
 import axios from 'axios'
 import '../../../../global.css'
 
-async function getReport(query, variables) {
+async function getReport(variables) {
+  const query = `
+  query GetReport($targetId: String!, $cycleId: String!) {
+    getReport(targetId: $targetId, cycleId: $cycleId) {
+      _id {
+        target
+        cycle
+      }
+      remarks
+    }
+  }`
   try {
     const response = await axios.post('http://localhost:8080/graphql', {
       query,
@@ -40,15 +50,20 @@ async function getFullReport(variables) {
   const query = `
       query GetReport($targetId: String!, $cycleId: String!) {
         getReport(targetId: $targetId, cycleId: $cycleId) {
-          _id {
+          _id{ 
             target
             cycle
           }
+
           remarks
-          reviews{
-            peer
-            self
-          }
+          status
+           reviews {
+            peer {
+              grades {
+                metric 
+              }
+            }
+           }
         }
       }`
 
@@ -68,27 +83,16 @@ async function Report({ params }) {
 
   const targetId = params.id
   const cycleId = params.cycleId
-  const query = `
-      query GetReport($targetId: String!, $cycleId: String!) {
-        getReport(targetId: $targetId, cycleId: $cycleId) {
-          _id {
-            target
-            cycle
-          }
-          remarks
-        }
-      }`
 
   // const status = undefined
   const variables = { targetId, cycleId }
 
   const user = await getUser(params)
-  const report = await getReport(query, variables)
+  const report = await getReport(variables)
   const fullReport = await getFullReport(variables)
 
-
-  console.log('full report console',fullReport)
-  console.log('paramsss console ------>',params)
+  console.log('full report console', fullReport)
+  console.log('paramsss console ------>', params)
 
   return (
     <div>

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -1,11 +1,22 @@
+import { ApolloWrapper } from "@/lib/apollo-wrapper";
+import { getClient } from "@/lib/client";
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+
+  const client = getClient()
+
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <ApolloWrapper
+          initialApolloState={client.cache.extract()}
+        >
+          {children}
+        </ApolloWrapper>
+      </body>
     </html>
   );
 }

--- a/apps/client/app/managerpanel/page.tsx
+++ b/apps/client/app/managerpanel/page.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button';
 
 function UserItem({ user }) {
 
-  const cycleId = "64e605dff9098d208418d435"
+  const cycleId = "64e46166c1903f7622ec9852"
 
 
   return (
@@ -22,7 +22,7 @@ function UserItem({ user }) {
   );
 }
 
-export default function Dashboard() {
+export default function ManagerPanel() {
   const [users, setUsers] = useState([])
 
   const getUsersQuery = `{

--- a/apps/client/app/page.tsx
+++ b/apps/client/app/page.tsx
@@ -1,6 +1,5 @@
 
 import './global.css'
-
 export default function Page() {
   return (
     <div>

--- a/apps/client/components.json
+++ b/apps/client/components.json
@@ -10,7 +10,7 @@
     "cssVariables": true
   },
   "aliases": {
-    "components": "@/src/components",
+    "components": "@/components",
     "utils": "@/lib/utils"
   }
 }

--- a/apps/client/components/ui/table.tsx
+++ b/apps/client/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn("bg-primary font-medium text-primary-foreground", className)}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className
+    )}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/apps/client/lib/apollo-wrapper.js
+++ b/apps/client/lib/apollo-wrapper.js
@@ -1,0 +1,53 @@
+'use client'
+
+import { ApolloLink, HttpLink } from '@apollo/client'
+import {
+  ApolloNextAppProvider,
+  NextSSRInMemoryCache,
+  NextSSRApolloClient,
+  SSRMultipartLink,
+} from '@apollo/experimental-nextjs-app-support/ssr'
+
+// have a function to create a client for you
+function makeClient() {
+  const httpLink = new HttpLink({
+    // uri: process.env.GRAPHQL_API_URL,
+
+    uri: 'http://localhost:4000',
+    fetchOptions: { cache: 'no-store' },
+  })
+
+  return new NextSSRApolloClient({
+    cache: new NextSSRInMemoryCache(),
+    link:
+      typeof window === 'undefined'
+        ? ApolloLink.from([
+            new SSRMultipartLink({
+              stripDefer: true,
+            }),
+            httpLink,
+          ])
+        : httpLink,
+  })
+}
+// !!! IMPORTANT !!!
+
+// Resetting singletons between tests.
+// This package uses some singleton instances on the Browser side - if you are writing tests, you must reset them between tests.
+
+// For that, you can use the resetNextSSRApolloSingletons helper:
+
+// import { resetNextSSRApolloSingletons } from "@apollo/experimental-nextjs-app-support/ssr";
+
+// afterEach(resetNextSSRApolloSingletons);
+
+export function ApolloWrapper({ children, initialApolloState }) {
+  return (
+    <ApolloNextAppProvider
+      initialApolloState={initialApolloState}
+      makeClient={makeClient}
+    >
+      {children}
+    </ApolloNextAppProvider>
+  )
+}

--- a/apps/client/lib/client.js
+++ b/apps/client/lib/client.js
@@ -1,0 +1,19 @@
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
+import {
+  NextSSRInMemoryCache,
+  NextSSRApolloClient,
+} from '@apollo/experimental-nextjs-app-support/ssr'
+import { registerApolloClient } from '@apollo/experimental-nextjs-app-support/rsc'
+
+export const { getClient } = registerApolloClient(() => {
+  return new NextSSRApolloClient({
+    cache: new NextSSRInMemoryCache(),
+    link: new HttpLink({
+      // https://studio.apollographql.com/public/spacex-l4uc6p/
+      uri: process.env.GRAPHQL_API_URL,
+      // you can disable result caching here if you want to
+      // (this does not work if you are rendering your page with `export const dynamic = "force-static"`)
+      // fetchOptions: { cache: "no-store" },
+    }),
+  })
+})

--- a/apps/client/lib/queries.ts
+++ b/apps/client/lib/queries.ts
@@ -1,0 +1,69 @@
+import { gql } from '@apollo/client'
+
+export const GET_USERS = gql`
+  query Query {
+    getUsers {
+      _id
+      fullName
+      title
+      teamName
+    }
+  }
+`
+
+export const GET_FULLREPORT = gql`
+  query GetReport($targetId: String!, $cycleId: String!) {
+    getReport(targetId: $targetId, cycleId: $cycleId) {
+      _id {
+        cycle
+        target
+      }
+      remarks
+      reviews {
+        peer {
+          grades {
+            comment
+            maxRating
+            metric
+            rating
+          }
+          isDeclined
+          reviewer
+          submitted
+        }
+        self {
+          grades {
+            comment
+            maxRating
+            metric
+            rating
+          }
+          isDeclined
+          reviewer
+          submitted
+        }
+      }
+      status
+    }
+  }
+`
+
+export const GET_USER_FULLNAME_BY_ID = gql`
+  query getUser($id: String) {
+    getUser(id: $id) {
+      fullName
+    }
+  }
+`
+
+export const GET_REPORT_FOR_EMPLOYEE = gql`
+  query GetReport($targetId: String!, $cycleId: String!) {
+    getReport(targetId: $targetId, cycleId: $cycleId) {
+      _id {
+        target
+        cycle
+      }
+      remarks
+    }
+  }
+`

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -9,11 +9,12 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "axios": "^1.4.0",
+    "@apollo/client": "^3.8.0-rc.2",
+    "@apollo/experimental-nextjs-app-support": "^0.4.1",
     "@radix-ui/react-slot": "^1.0.2",
+    "axios": "^1.4.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
- 
     "init": "^0.1.2",
     "lucide-react": "^0.268.0",
     "next": "^13.4.1",
@@ -21,7 +22,6 @@
     "react-dom": "^18.2.0",
     "tailwind-merge": "^1.14.0",
     "tailwindcss-animate": "^1.0.6"
-
   },
   "devDependencies": {
     "@types/node": "^17.0.12",

--- a/apps/client/tsconfig.json
+++ b/apps/client/tsconfig.json
@@ -24,7 +24,7 @@
     "src/**/*",
     "components/**/*",
     ".next/types/**/*.ts"
-  ],
+, "lib/apollo-wrapper.js"  ],
   "exclude": [
     "node_modules"
   ]

--- a/apps/server/dist/index.js
+++ b/apps/server/dist/index.js
@@ -1,0 +1,58 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const mongoose_1 = __importDefault(require("mongoose"));
+const constants_1 = require("./src/lib/constants");
+const router_1 = __importDefault(require("./src/router"));
+const cors_1 = __importDefault(require("cors"));
+const server_1 = require("@apollo/server");
+const standalone_1 = require("@apollo/server/standalone");
+const fs_1 = require("fs");
+const resolvers_1 = require("./src/resolvers");
+const app = (0, express_1.default)();
+app.use(express_1.default.json());
+app.use((0, cors_1.default)());
+app.use(router_1.default);
+mongoose_1.default.connect(constants_1.MONGODB_URL);
+const db = mongoose_1.default.connection;
+const typeDefs = (0, fs_1.readFileSync)('./src/schema.graphql', 'utf-8');
+db.on('error', console.error.bind(console, 'MongoDB connection error:'));
+db.once('open', () => {
+    console.log('Connected to MongoDB!');
+});
+const apolloServer = new server_1.ApolloServer({
+    typeDefs,
+    resolvers: resolvers_1.resolvers,
+});
+(0, standalone_1.startStandaloneServer)(apolloServer, { listen: { port: 4000 } })
+    .then(({ url }) => {
+    console.log('🚀 Server ready at', url);
+})
+    .catch((error) => {
+    console.error('An error occurred:', error);
+});
+console.log('for arol listening now');
+const server = app.listen(8080, () => {
+    console.log('connectig to db...', constants_1.MONGODB_URL);
+    console.log('360 review server is listening on port 8080! 🤜🤛');
+});
+function shutdown() {
+    console.log('for craig hello');
+    server.close(() => {
+        mongoose_1.default.connection.close().then(() => {
+            process.exit(0);
+        });
+    });
+    console.log('👋 SIGTERM RECEIVED. Shutting down gracefully');
+}
+process.on('SIGTERM', () => {
+    console.log('SIGTERM');
+    shutdown();
+});
+process.on('SIGUSR2', () => {
+    console.log('SIGUSR2');
+    shutdown();
+});

--- a/apps/server/dist/src/lib/constants.js
+++ b/apps/server/dist/src/lib/constants.js
@@ -1,0 +1,16 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.MONGODB_URL = void 0;
+const dotenv_1 = __importDefault(require("dotenv"));
+dotenv_1.default.config();
+exports.MONGODB_URL = ensureEnvVarExist('MONGODB_URL');
+function ensureEnvVarExist(name) {
+    const value = process.env[name];
+    if (value === undefined) {
+        throw new Error(`${name} must be defined as an env variable`);
+    }
+    return value;
+}

--- a/apps/server/dist/src/lib/mongoose/models/Report.js
+++ b/apps/server/dist/src/lib/mongoose/models/Report.js
@@ -1,0 +1,32 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const mongoose_1 = require("mongoose");
+const GradeSchema = new mongoose_1.Schema({
+    metric: String,
+    // rating === 0 when not graded
+    rating: Number,
+    maxRating: Number,
+    comment: String,
+});
+const ReviewSchema = new mongoose_1.Schema({
+    // I have no idea why this has to spell out 'Schema.Types.ObjectId'
+    // but in a type declaration, I can just use 'ObjectId'
+    reviewer: mongoose_1.Schema.Types.ObjectId,
+    submitted: Boolean,
+    grades: [GradeSchema],
+}, 
+//* Set createdAt and updatedAt
+{ timestamps: true });
+const ReportSchema = new mongoose_1.Schema({
+    _id: { target: mongoose_1.Schema.Types.ObjectId, cycle: mongoose_1.Schema.Types.ObjectId },
+    remarks: String,
+    status: String,
+    reviews: {
+        peer: [ReviewSchema],
+        self: ReviewSchema,
+    },
+}, 
+// Set createdAt and updatedAt
+{ timestamps: true });
+const Report = (0, mongoose_1.model)('Report', ReportSchema);
+exports.default = Report;

--- a/apps/server/dist/src/lib/mongoose/models/User.js
+++ b/apps/server/dist/src/lib/mongoose/models/User.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const mongoose_1 = require("mongoose");
+const userSchema = new mongoose_1.Schema({
+    email: String,
+    fullName: String,
+    hashedPw: String,
+    title: String,
+    isOlga: Boolean,
+    photo: String,
+    teamName: String,
+    companyName: String,
+});
+const User = (0, mongoose_1.model)('User', userSchema);
+exports.default = User;

--- a/apps/server/dist/src/lib/mongoose/seeders/faker.js
+++ b/apps/server/dist/src/lib/mongoose/seeders/faker.js
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const en_GB_1 = require("@faker-js/faker/locale/en_GB");
+const SEED = 1;
+const faker = en_GB_1.faker;
+faker.seed(SEED);
+exports.default = faker;

--- a/apps/server/dist/src/lib/mongoose/seeders/generate-reports.js
+++ b/apps/server/dist/src/lib/mongoose/seeders/generate-reports.js
@@ -1,0 +1,64 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const faker_1 = __importDefault(require("./faker"));
+function generateGrades(count, maxRating, isFilled) {
+    const grades = [];
+    const metrics = faker_1.default.helpers.arrayElements([
+        'Looks',
+        'Coding',
+        'Punctuality',
+        'Cooking',
+        'Volleyball',
+        'Skating',
+        'Crime',
+        'Being From Cuba',
+        'Raw Power',
+        'Animal Magnetism',
+    ], count);
+    for (let i = 0; i < count; i++) {
+        const grade = {
+            metric: metrics[i],
+            rating: isFilled ? faker_1.default.number.int({ min: 1, max: maxRating }) : 0,
+            maxRating: maxRating,
+            comment: isFilled ? faker_1.default.lorem.lines({ min: 1, max: 3 }) : '',
+        };
+        grades.push(grade);
+    }
+    return grades;
+}
+function generateReview(reviewer, metricCount, maxRating, isGraded = false) {
+    const review = {
+        reviewer: reviewer,
+        isDeclined: false,
+        submitted: isGraded,
+        grades: generateGrades(metricCount, maxRating, isGraded),
+    };
+    return review;
+}
+function generateReport(target, cycle, reviewers, metricCount, maxRating, areReviewsEmpty) {
+    const peerReviews = [];
+    for (let i = 0; i < reviewers.length; i++) {
+        const reviewerId = reviewers[i];
+        const review = generateReview(reviewerId, metricCount, maxRating, areReviewsEmpty);
+        peerReviews.push(review);
+    }
+    const report = {
+        _id: { target, cycle },
+        remarks: faker_1.default.lorem.paragraph({ min: 2, max: 4 }),
+        status: faker_1.default.helpers.arrayElement([
+            'Nomination',
+            'Review',
+            'Report',
+            'Completed',
+        ]),
+        reviews: {
+            peer: peerReviews,
+            self: generateReview(target, metricCount, maxRating),
+        },
+    };
+    return report;
+}
+exports.default = generateReport;

--- a/apps/server/dist/src/lib/mongoose/seeders/generate-users.js
+++ b/apps/server/dist/src/lib/mongoose/seeders/generate-users.js
@@ -1,0 +1,24 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const faker_1 = __importDefault(require("./faker"));
+function generateUsers(count) {
+    const users = [];
+    for (let i = 0; i < count; i++) {
+        const user = {
+            email: faker_1.default.internet.email(),
+            fullName: faker_1.default.person.fullName(),
+            hashedPw: faker_1.default.string.hexadecimal(),
+            title: faker_1.default.person.jobTitle(),
+            isOlga: faker_1.default.datatype.boolean(),
+            photo: faker_1.default.internet.avatar(),
+            teamName: faker_1.default.helpers.arrayElement(['Staff, Students, Instructors']),
+            companyName: 'Arol.Dev',
+        };
+        users.push(user);
+    }
+    return users;
+}
+exports.default = generateUsers;

--- a/apps/server/dist/src/lib/mongoose/seeders/seeder.js
+++ b/apps/server/dist/src/lib/mongoose/seeders/seeder.js
@@ -1,0 +1,85 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const mongoose_1 = __importDefault(require("mongoose"));
+const generate_users_1 = __importDefault(require("./generate-users"));
+require("dotenv/config");
+const User_1 = __importDefault(require("../models/User"));
+const generate_reports_1 = __importDefault(require("./generate-reports"));
+const Report_1 = __importDefault(require("../models/Report"));
+const NUMBER_OF_USERS = 10;
+const NUMBER_OF_PEER_REVIEWS = 1;
+const NUMBER_OF_METRICS = 3;
+const MAX_RATING = 5;
+const mongoURL = process.env.MONGODB_URL;
+// Connect to mongodb implementation
+function seedDb() {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            if (mongoURL === undefined)
+                throw new Error('Could not get MongoDB URL from .env');
+            yield mongoose_1.default.connect(mongoURL);
+            yield mongoose_1.default.connection.db.dropDatabase();
+            console.log('🧑🏻‍💻👍🏻 Connected to DB');
+            yield seedData(NUMBER_OF_USERS);
+            mongoose_1.default.connection.close();
+        }
+        catch (error) {
+            console.log(error.message);
+        }
+    });
+}
+function seedData(count) {
+    return __awaiter(this, void 0, void 0, function* () {
+        try {
+            const userInput = (0, generate_users_1.default)(count);
+            const users = yield User_1.default.insertMany(userInput);
+            if (!users)
+                throw new Error('User.insertMany() failed');
+            console.log(`${users.length} users have been added to the database`);
+            console.log(users);
+            const fakeCycle = new mongoose_1.default.Types.ObjectId();
+            const reportInput = [];
+            users.forEach((user, index) => {
+                const reviewers = pickRandomReviewers(user._id, users, NUMBER_OF_PEER_REVIEWS);
+                //! ~half the reports will have empty reviews
+                const areReviewsEmpty = index < users.length / 2;
+                const report = (0, generate_reports_1.default)(user._id, fakeCycle, reviewers, NUMBER_OF_METRICS, MAX_RATING, areReviewsEmpty);
+                reportInput.push(report);
+            });
+            const reports = yield Report_1.default.insertMany(reportInput);
+            if (!reports)
+                throw new Error('Report.insertMany() failed');
+            console.log(`${reports.length} reports have been added to the database`);
+            console.log(reports[8].reviews.peer[0]);
+        }
+        catch (error) {
+            console.log(error.message);
+        }
+    });
+}
+function pickRandomReviewers(targetId, users, reviewerCount) {
+    const reviewers = [];
+    while (reviewers.length < reviewerCount) {
+        const i = getRandomInt(users.length - 1);
+        const user = users[i];
+        if (user._id !== targetId)
+            reviewers.push(user._id);
+    }
+    return reviewers;
+}
+function getRandomInt(max) {
+    return Math.floor(Math.random() * max);
+}
+exports.default = seedDb;

--- a/apps/server/dist/src/lib/types/User.js
+++ b/apps/server/dist/src/lib/types/User.js
@@ -1,0 +1,2 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/apps/server/dist/src/resolvers.js
+++ b/apps/server/dist/src/resolvers.js
@@ -30,7 +30,6 @@ exports.resolvers = {
             }
         }),
         getUser: (_, { id }) => __awaiter(void 0, void 0, void 0, function* () {
-            console.log('this is the id i get', id);
             try {
                 const user = yield User_1.default.findById(id);
                 return user;
@@ -60,7 +59,6 @@ exports.resolvers = {
         }),
         getReport: (_, { targetId, cycleId, }) => __awaiter(void 0, void 0, void 0, function* () {
             try {
-                console.log('this is what i get ', targetId, cycleId);
                 const report = yield Report_1.default.findOne({
                     '_id.target': targetId,
                     '_id.cycle': cycleId,

--- a/apps/server/dist/src/resolvers.js
+++ b/apps/server/dist/src/resolvers.js
@@ -1,0 +1,75 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.resolvers = void 0;
+const Report_1 = __importDefault(require("./lib/mongoose/models/Report"));
+const User_1 = __importDefault(require("./lib/mongoose/models/User"));
+exports.resolvers = {
+    Query: {
+        hello: () => {
+            return 'Hello world!';
+        },
+        getUsers: () => __awaiter(void 0, void 0, void 0, function* () {
+            try {
+                const users = yield User_1.default.find();
+                return users;
+            }
+            catch (error) {
+                throw new Error('Error fetching users from the database');
+            }
+        }),
+        getUser: (_, { id }) => __awaiter(void 0, void 0, void 0, function* () {
+            console.log('this is the id i get', id);
+            try {
+                const user = yield User_1.default.findById(id);
+                return user;
+            }
+            catch (error) {
+                throw new Error('Error fetching users from the database');
+            }
+        }),
+        createUser: (_, { input }) => __awaiter(void 0, void 0, void 0, function* () {
+            try {
+                const newUser = new User_1.default(input);
+                const savedUser = yield newUser.save();
+                return savedUser;
+            }
+            catch (error) {
+                throw new Error('Error creating a new user and saving it to the database');
+            }
+        }),
+        changeUser: (_, { input }) => __awaiter(void 0, void 0, void 0, function* () {
+            try {
+                const updatedUser = yield User_1.default.findOneAndUpdate({ email: input.email }, input, { new: true });
+                return updatedUser;
+            }
+            catch (error) {
+                throw new Error('Error updating a user in the database');
+            }
+        }),
+        getReport: (_, { targetId, cycleId, }) => __awaiter(void 0, void 0, void 0, function* () {
+            try {
+                console.log('this is what i get ', targetId, cycleId);
+                const report = yield Report_1.default.findOne({
+                    '_id.target': targetId,
+                    '_id.cycle': cycleId,
+                });
+                return report;
+            }
+            catch (error) {
+                throw new Error('Error fetching report from the database');
+            }
+        }),
+    },
+};

--- a/apps/server/dist/src/router.js
+++ b/apps/server/dist/src/router.js
@@ -1,0 +1,29 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const express_1 = __importDefault(require("express"));
+const Report_1 = __importDefault(require("./lib/mongoose/models/Report"));
+const router = express_1.default.Router();
+router.get('/', (_, res) => __awaiter(void 0, void 0, void 0, function* () {
+    try {
+        const data = yield Report_1.default.find();
+        console.log('data', data);
+        res.json(data);
+    }
+    catch (error) {
+        console.error(error);
+        res.sendStatus(500);
+    }
+}));
+exports.default = router;

--- a/apps/server/dist/src/seed.js
+++ b/apps/server/dist/src/seed.js
@@ -1,0 +1,7 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const seeder_1 = __importDefault(require("./lib/mongoose/seeders/seeder"));
+(0, seeder_1.default)();

--- a/apps/server/index.ts
+++ b/apps/server/index.ts
@@ -144,7 +144,6 @@ const rootValue = {
         '_id.target': targetId,
         '_id.cycle': cycleId,
       })
-      console.log('report found', report)
       return report
     } catch (error) {
       throw new Error('Error fetching report from the database')

--- a/apps/server/index.ts
+++ b/apps/server/index.ts
@@ -3,11 +3,10 @@ import mongoose from 'mongoose'
 import { MONGODB_URL } from './src/lib/constants'
 import router from './src/router'
 import cors from 'cors'
-import { graphqlHTTP } from 'express-graphql'
-import { buildSchema } from 'graphql'
-import User from './src/lib/mongoose/models/User'
-import { Input } from './src/lib/types/User'
-import Report from './src/lib/mongoose/models/Report'
+import { ApolloServer } from '@apollo/server'
+import { startStandaloneServer } from '@apollo/server/standalone'
+import { read, readFileSync } from 'fs'
+import { resolvers } from './src/resolvers'
 
 const app = express()
 app.use(express.json())
@@ -18,147 +17,26 @@ app.use(router)
 mongoose.connect(MONGODB_URL)
 const db = mongoose.connection
 
+const typeDefs = readFileSync('./src/schema.graphql', 'utf-8')
+
 db.on('error', console.error.bind(console, 'MongoDB connection error:'))
 db.once('open', () => {
   console.log('Connected to MongoDB!')
 })
-const schema = buildSchema(`
-type Query {
-  hello: String
-  getUsers: [User]
-  getReport(targetId: String!, cycleId: String!): Report
-  getUser(id: String): User
-  
-}
 
-input UserInput {
-  email: String!
-  fullName: String
-  hashedPw: String
-  title: String
-  isOlga: Boolean
-  photo: String
-  teamName: String
-  companyName: String
-}
+const apolloServer = new ApolloServer({
+  typeDefs,
+  resolvers,
+})
 
-type Mutation {
-  createUser(input: UserInput): User
-  changeUser(input: UserInput): User
-}
-
-type User {
-  _id: String,
-  email: String
-  fullName: String
-  hashedPw: String
-  title: String
-  isOlga: Boolean
-  photo: String
-  teamName: String
-  companyName: String
-}
-
-
-type ReportID {
-  target: String
-  cycle: String
-}
-
-type Report {
-  _id: ReportID
-  remarks: String
-  status: String
-  reviews: Reviews
-}
-
-type Reviews {
-  self : Review
-  peer : [Review]
-}
-type Review {
-  reviewer: String
-  isDeclined: Boolean
-  submitted: Boolean
-  grades: [Grade]
-}
-
-type Grade {
-  metric: String
-  rating: Int
-  maxRating: Int
-  comment: String
- 
-}`)
-
-const rootValue = {
-  hello: () => {
-    return 'Hello world!'
-  },
-  getUsers: async () => {
-    try {
-      const users = await User.find()
-      return users
-    } catch (error) {
-      throw new Error('Error fetching users from the database')
-    }
-  },
-  getUser: async ({ id }: { id: String }) => {
-    try {
-      const user = await User.findById(id)
-      return user
-    } catch (error) {
-      throw new Error('Error fetching users from the database')
-    }
-  },
-  createUser: async ({ input }: { input: Input }) => {
-    try {
-      const newUser = new User(input)
-      const savedUser = await newUser.save()
-      return savedUser
-    } catch (error) {
-      throw new Error('Error creating a new user and saving it to the database')
-    }
-  },
-  changeUser: async ({ input }: { input: Input }) => {
-    try {
-      const updatedUser = await User.findOneAndUpdate(
-        { email: input.email },
-        input,
-        { new: true }
-      )
-      return updatedUser
-    } catch (error) {
-      throw new Error('Error updating a user in the database')
-    }
-  },
-  getReport: async ({
-    targetId,
-    cycleId,
-  }: {
-    targetId: String
-    cycleId: String
-  }) => {
-    try {
-      const report = await Report.findOne({
-        '_id.target': targetId,
-        '_id.cycle': cycleId,
-      })
-      return report
-    } catch (error) {
-      throw new Error('Error fetching report from the database')
-    }
-  },
-}
-
-app.use(
-  '/graphql',
-  graphqlHTTP({
-    schema: schema,
-    rootValue: rootValue,
-    graphiql: true,
+startStandaloneServer(apolloServer, { listen: { port: 4000 } })
+  .then(({ url }) => {
+    console.log('🚀 Server ready at', url)
   })
-)
+  .catch((error) => {
+    console.error('An error occurred:', error)
+  })
+
 console.log('for arol listening now')
 const server = app.listen(8080, () => {
   console.log('connectig to db...', MONGODB_URL)

--- a/apps/server/index.ts
+++ b/apps/server/index.ts
@@ -5,7 +5,7 @@ import router from './src/router'
 import cors from 'cors'
 import { ApolloServer } from '@apollo/server'
 import { startStandaloneServer } from '@apollo/server/standalone'
-import { read, readFileSync } from 'fs'
+import { readFileSync } from 'fs'
 import { resolvers } from './src/resolvers'
 
 const app = express()

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -4,16 +4,21 @@
   "main": "index.ts",
   "license": "MIT",
   "scripts": {
-    "dev": "nodemon index.ts",
+    "compile": "tsc",
+    "start": "npm run compile && node ./dist/index.js",
+    "dev": "npm run compile  && nodemon index.ts",
     "seed": "ts-node src/seed.ts"
   },
   "dependencies": {
+    "@apollo/server": "^4.9.1",
     "@types/cors": "^2.8.13",
     "@types/express": "^4.17.17",
     "@types/mongoose": "^5.11.97",
+    "@types/node": "^20.5.4",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "express-graphql": "^0.12.0",
+    "fs": "^0.0.1-security",
     "graphql": "^16.8.0",
     "mongoose": "^7.4.3",
     "typescript": "^5.1.6"

--- a/apps/server/src/resolvers.ts
+++ b/apps/server/src/resolvers.ts
@@ -1,0 +1,72 @@
+import Report from './lib/mongoose/models/Report'
+import User from './lib/mongoose/models/User'
+import { Input } from './lib/types/User'
+
+export const resolvers = {
+  Query: {
+    hello: () => {
+      return 'Hello world!'
+    },
+    getUsers: async () => {
+      try {
+        const users = await User.find()
+        return users
+      } catch (error) {
+        throw new Error('Error fetching users from the database')
+      }
+    },
+    getUser: async (_: any, { id }: { id: String }) => {
+      console.log('this is the id i get', id)
+      try {
+        const user = await User.findById(id)
+        return user
+      } catch (error) {
+        throw new Error('Error fetching users from the database')
+      }
+    },
+    createUser: async (_: any, { input }: { input: Input }) => {
+      try {
+        const newUser = new User(input)
+        const savedUser = await newUser.save()
+        return savedUser
+      } catch (error) {
+        throw new Error(
+          'Error creating a new user and saving it to the database'
+        )
+      }
+    },
+    changeUser: async (_: any, { input }: { input: Input }) => {
+      try {
+        const updatedUser = await User.findOneAndUpdate(
+          { email: input.email },
+          input,
+          { new: true }
+        )
+        return updatedUser
+      } catch (error) {
+        throw new Error('Error updating a user in the database')
+      }
+    },
+    getReport: async (
+      _: any,
+      {
+        targetId,
+        cycleId,
+      }: {
+        targetId: String
+        cycleId: String
+      }
+    ) => {
+      try {
+        console.log('this is what i get ', targetId, cycleId)
+        const report = await Report.findOne({
+          '_id.target': targetId,
+          '_id.cycle': cycleId,
+        })
+        return report
+      } catch (error) {
+        throw new Error('Error fetching report from the database')
+      }
+    },
+  },
+}

--- a/apps/server/src/resolvers.ts
+++ b/apps/server/src/resolvers.ts
@@ -16,7 +16,6 @@ export const resolvers = {
       }
     },
     getUser: async (_: any, { id }: { id: String }) => {
-      console.log('this is the id i get', id)
       try {
         const user = await User.findById(id)
         return user
@@ -58,7 +57,6 @@ export const resolvers = {
       }
     ) => {
       try {
-        console.log('this is what i get ', targetId, cycleId)
         const report = await Report.findOne({
           '_id.target': targetId,
           '_id.cycle': cycleId,

--- a/apps/server/src/resolvers.ts
+++ b/apps/server/src/resolvers.ts
@@ -23,29 +23,6 @@ export const resolvers = {
         throw new Error('Error fetching users from the database')
       }
     },
-    createUser: async (_: any, { input }: { input: Input }) => {
-      try {
-        const newUser = new User(input)
-        const savedUser = await newUser.save()
-        return savedUser
-      } catch (error) {
-        throw new Error(
-          'Error creating a new user and saving it to the database'
-        )
-      }
-    },
-    changeUser: async (_: any, { input }: { input: Input }) => {
-      try {
-        const updatedUser = await User.findOneAndUpdate(
-          { email: input.email },
-          input,
-          { new: true }
-        )
-        return updatedUser
-      } catch (error) {
-        throw new Error('Error updating a user in the database')
-      }
-    },
     getReport: async (
       _: any,
       {
@@ -64,6 +41,33 @@ export const resolvers = {
         return report
       } catch (error) {
         throw new Error('Error fetching report from the database')
+      }
+    },
+  },
+
+  Mutation: {
+    changeUser: async (_: any, { input }: { input: Input }) => {
+      try {
+        const updatedUser = await User.findOneAndUpdate(
+          { email: input.email },
+          input,
+          { new: true }
+        )
+        return updatedUser
+      } catch (error) {
+        throw new Error('Error updating a user in the database')
+      }
+    },
+
+    createUser: async (_: any, { input }: { input: Input }) => {
+      try {
+        const newUser = new User(input)
+        const savedUser = await newUser.save()
+        return savedUser
+      } catch (error) {
+        throw new Error(
+          'Error creating a new user and saving it to the database'
+        )
       }
     },
   },

--- a/apps/server/src/schema.graphql
+++ b/apps/server/src/schema.graphql
@@ -3,6 +3,9 @@ type Query {
   getUsers: [User]
   getReport(targetId: String!, cycleId: String!): Report
   getUser(id: String): User
+}
+
+type Mutation {
   createUser(input: UserInput): User
   changeUser(input: UserInput): User
 }
@@ -18,10 +21,6 @@ input UserInput {
   companyName: String
 }
 
-# type Mutation {
-#   createUser(input: UserInput): User
-#   changeUser(input: UserInput): User
-# }
 
 type User {
   _id: String,

--- a/apps/server/src/schema.graphql
+++ b/apps/server/src/schema.graphql
@@ -1,0 +1,67 @@
+type Query {  
+  hello: String
+  getUsers: [User]
+  getReport(targetId: String!, cycleId: String!): Report
+  getUser(id: String): User
+  createUser(input: UserInput): User
+  changeUser(input: UserInput): User
+}
+
+input UserInput {
+  email: String!
+  fullName: String
+  hashedPw: String
+  title: String
+  isOlga: Boolean
+  photo: String
+  teamName: String
+  companyName: String
+}
+
+# type Mutation {
+#   createUser(input: UserInput): User
+#   changeUser(input: UserInput): User
+# }
+
+type User {
+  _id: String,
+  email: String
+  fullName: String
+  hashedPw: String
+  title: String
+  isOlga: Boolean
+  photo: String
+  teamName: String
+  companyName: String
+}
+
+
+type ReportID {
+  target: String
+  cycle: String
+}
+
+type Report {
+  _id: ReportID
+  remarks: String
+  status: String
+  reviews: Reviews
+}
+
+type Reviews {
+  self : Review
+  peer : [Review]
+}
+type Review {
+  reviewer: String
+  isDeclined: Boolean
+  submitted: Boolean
+  grades: [Grade]
+}
+
+type Grade {
+  metric: String
+  rating: Int
+  maxRating: Int
+  comment: String
+}

--- a/apps/server/tsconfig.json
+++ b/apps/server/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Language and Environment */
     "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "lib": ["es2020"],                                   /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -27,12 +27,12 @@
     /* Modules */
     "module": "commonjs",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "node",                       /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    "rootDirs": ["src"],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"],                                      /* Specify type package names to be included without being referenced in a source file. */
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,8 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**"]
+      "outputs": [".next/**", "!.next/cache/**"],
+      "env":["GRAPHQL_API_URL"]
     },
     "lint": {},
     "dev": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,180 @@
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
   integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
 
+"@apollo/cache-control-types@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@apollo/cache-control-types/-/cache-control-types-1.0.3.tgz#5da62cf64c3b4419dabfef4536b57a40c8ff0b47"
+  integrity sha512-F17/vCp7QVwom9eG7ToauIKdAxpSoadsJnqIfyryLFSkLSOEqu+eC5Z3N8OXcUVStuOMcNHlyraRsA6rRICu4g==
+
+"@apollo/client@^3.8.0-rc.2":
+  version "3.8.0-rc.2"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.8.0-rc.2.tgz#3ba6f1fb6fff23a08800c4733d09b89428111b09"
+  integrity sha512-OQhMbYhNscVwqfxb9diOZpra4m4Vr+CbzkHZGdg51+BADzUeQCEaQyeKhClJqh1HAH3kIqRf+pD9otzuMDhcSg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/context" "^0.7.3"
+    "@wry/equality" "^0.5.6"
+    "@wry/trie" "^0.4.3"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.17.5"
+    prop-types "^15.7.2"
+    response-iterator "^0.2.6"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
+"@apollo/experimental-nextjs-app-support@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@apollo/experimental-nextjs-app-support/-/experimental-nextjs-app-support-0.4.1.tgz#03662bb284ba2e677cb979c741d7783a55586e74"
+  integrity sha512-xW+RVxaeOboJvol4HUhgP6YZvwamIz8Gqba3II5Uviy1++kqsE0I/q2WT03laIEwTB8YBO25tY9EmQ1mImRWyw==
+  dependencies:
+    superjson "^1.12.2"
+    ts-invariant "^0.10.3"
+
+"@apollo/protobufjs@1.2.7":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@apollo/protobufjs/-/protobufjs-1.2.7.tgz#3a8675512817e4a046a897e5f4f16415f16a7d8a"
+  integrity sha512-Lahx5zntHPZia35myYDBRuF58tlwPskwHc5CWBZC/4bMKB6siTBWwtMrkqXcsNwQiFSzSx5hKdRPUmemrEp3Gg==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.2"
+    "@protobufjs/base64" "^1.1.2"
+    "@protobufjs/codegen" "^2.0.4"
+    "@protobufjs/eventemitter" "^1.1.0"
+    "@protobufjs/fetch" "^1.1.0"
+    "@protobufjs/float" "^1.0.2"
+    "@protobufjs/inquire" "^1.1.0"
+    "@protobufjs/path" "^1.1.2"
+    "@protobufjs/pool" "^1.1.0"
+    "@protobufjs/utf8" "^1.1.0"
+    "@types/long" "^4.0.0"
+    long "^4.0.0"
+
+"@apollo/server-gateway-interface@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/server-gateway-interface/-/server-gateway-interface-1.1.1.tgz#a79632aa921edefcd532589943f6b97c96fa4d3c"
+  integrity sha512-pGwCl/po6+rxRmDMFgozKQo2pbsSwE91TpsDBAOgf74CRDPXHHtM88wbwjab0wMMZh95QfR45GGyDIdhY24bkQ==
+  dependencies:
+    "@apollo/usage-reporting-protobuf" "^4.1.1"
+    "@apollo/utils.fetcher" "^2.0.0"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+    "@apollo/utils.logger" "^2.0.0"
+
+"@apollo/server@^4.9.1":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@apollo/server/-/server-4.9.1.tgz#dadad5f661db41260adecf0a5e3fa46f2232637e"
+  integrity sha512-uUzkHt7DU/NEdwMvkb4GZq8ho2EYJAJXTiBq0HUhhjOuxMVfZ7fbKgOIcSF33Ur7c67fLdWwulXMAvv89Cyv0w==
+  dependencies:
+    "@apollo/cache-control-types" "^1.0.3"
+    "@apollo/server-gateway-interface" "^1.1.1"
+    "@apollo/usage-reporting-protobuf" "^4.1.1"
+    "@apollo/utils.createhash" "^2.0.0"
+    "@apollo/utils.fetcher" "^2.0.0"
+    "@apollo/utils.isnodelike" "^2.0.0"
+    "@apollo/utils.keyvaluecache" "^2.1.0"
+    "@apollo/utils.logger" "^2.0.0"
+    "@apollo/utils.usagereporting" "^2.1.0"
+    "@apollo/utils.withrequired" "^2.0.0"
+    "@graphql-tools/schema" "^9.0.0"
+    "@josephg/resolvable" "^1.0.0"
+    "@types/express" "^4.17.13"
+    "@types/express-serve-static-core" "^4.17.30"
+    "@types/node-fetch" "^2.6.1"
+    async-retry "^1.2.1"
+    body-parser "^1.20.0"
+    cors "^2.8.5"
+    express "^4.17.1"
+    loglevel "^1.6.8"
+    lru-cache "^7.10.1"
+    negotiator "^0.6.3"
+    node-abort-controller "^3.1.1"
+    node-fetch "^2.6.7"
+    uuid "^9.0.0"
+    whatwg-mimetype "^3.0.0"
+
+"@apollo/usage-reporting-protobuf@^4.1.0", "@apollo/usage-reporting-protobuf@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/usage-reporting-protobuf/-/usage-reporting-protobuf-4.1.1.tgz#407c3d18c7fbed7a264f3b9a3812620b93499de1"
+  integrity sha512-u40dIUePHaSKVshcedO7Wp+mPiZsaU6xjv9J+VyxpoU/zL6Jle+9zWeG98tr/+SZ0nZ4OXhrbb8SNr0rAPpIDA==
+  dependencies:
+    "@apollo/protobufjs" "1.2.7"
+
+"@apollo/utils.createhash@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.createhash/-/utils.createhash-2.0.1.tgz#9d982a166833ce08265ff70f8ef781d65109bdaa"
+  integrity sha512-fQO4/ZOP8LcXWvMNhKiee+2KuKyqIcfHrICA+M4lj/h/Lh1H10ICcUtk6N/chnEo5HXu0yejg64wshdaiFitJg==
+  dependencies:
+    "@apollo/utils.isnodelike" "^2.0.1"
+    sha.js "^2.4.11"
+
+"@apollo/utils.dropunuseddefinitions@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.dropunuseddefinitions/-/utils.dropunuseddefinitions-2.0.1.tgz#916cd912cbd88769d3b0eab2d24f4674eeda8124"
+  integrity sha512-EsPIBqsSt2BwDsv8Wu76LK5R1KtsVkNoO4b0M5aK0hx+dGg9xJXuqlr7Fo34Dl+y83jmzn+UvEW+t1/GP2melA==
+
+"@apollo/utils.fetcher@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.fetcher/-/utils.fetcher-2.0.1.tgz#2f6e3edc8ce79fbe916110d9baaddad7e13d955f"
+  integrity sha512-jvvon885hEyWXd4H6zpWeN3tl88QcWnHp5gWF5OPF34uhvoR+DFqcNxs9vrRaBBSY3qda3Qe0bdud7tz2zGx1A==
+
+"@apollo/utils.isnodelike@^2.0.0", "@apollo/utils.isnodelike@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.isnodelike/-/utils.isnodelike-2.0.1.tgz#08a7e50f08d2031122efa25af089d1c6ee609f31"
+  integrity sha512-w41XyepR+jBEuVpoRM715N2ZD0xMD413UiJx8w5xnAZD2ZkSJnMJBoIzauK83kJpSgNuR6ywbV29jG9NmxjK0Q==
+
+"@apollo/utils.keyvaluecache@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.keyvaluecache/-/utils.keyvaluecache-2.1.1.tgz#f3f79a2f00520c6ab7a77a680a4e1fec4d19e1a6"
+  integrity sha512-qVo5PvUUMD8oB9oYvq4ViCjYAMWnZ5zZwEjNF37L2m1u528x5mueMlU+Cr1UinupCgdB78g+egA1G98rbJ03Vw==
+  dependencies:
+    "@apollo/utils.logger" "^2.0.1"
+    lru-cache "^7.14.1"
+
+"@apollo/utils.logger@^2.0.0", "@apollo/utils.logger@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.logger/-/utils.logger-2.0.1.tgz#74faeb97d7ad9f22282dfb465bcb2e6873b8a625"
+  integrity sha512-YuplwLHaHf1oviidB7MxnCXAdHp3IqYV8n0momZ3JfLniae92eYqMIx+j5qJFX6WKJPs6q7bczmV4lXIsTu5Pg==
+
+"@apollo/utils.printwithreducedwhitespace@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.printwithreducedwhitespace/-/utils.printwithreducedwhitespace-2.0.1.tgz#f4fadea0ae849af2c19c339cc5420d1ddfaa905e"
+  integrity sha512-9M4LUXV/fQBh8vZWlLvb/HyyhjJ77/I5ZKu+NBWV/BmYGyRmoEP9EVAy7LCVoY3t8BDcyCAGfxJaLFCSuQkPUg==
+
+"@apollo/utils.removealiases@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.removealiases/-/utils.removealiases-2.0.1.tgz#2873c93d72d086c60fc0d77e23d0f75e66a2598f"
+  integrity sha512-0joRc2HBO4u594Op1nev+mUF6yRnxoUH64xw8x3bX7n8QBDYdeYgY4tF0vJReTy+zdn2xv6fMsquATSgC722FA==
+
+"@apollo/utils.sortast@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.sortast/-/utils.sortast-2.0.1.tgz#58c90bb8bd24726346b61fa51ba7fcf06e922ef7"
+  integrity sha512-eciIavsWpJ09za1pn37wpsCGrQNXUhM0TktnZmHwO+Zy9O4fu/WdB4+5BvVhFiZYOXvfjzJUcc+hsIV8RUOtMw==
+  dependencies:
+    lodash.sortby "^4.7.0"
+
+"@apollo/utils.stripsensitiveliterals@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.stripsensitiveliterals/-/utils.stripsensitiveliterals-2.0.1.tgz#2f3350483be376a98229f90185eaf19888323132"
+  integrity sha512-QJs7HtzXS/JIPMKWimFnUMK7VjkGQTzqD9bKD1h3iuPAqLsxd0mUNVbkYOPTsDhUKgcvUOfOqOJWYohAKMvcSA==
+
+"@apollo/utils.usagereporting@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.usagereporting/-/utils.usagereporting-2.1.0.tgz#11bca6a61fcbc6e6d812004503b38916e74313f4"
+  integrity sha512-LPSlBrn+S17oBy5eWkrRSGb98sWmnEzo3DPTZgp8IQc8sJe0prDgDuppGq4NeQlpoqEHz0hQeYHAOA0Z3aQsxQ==
+  dependencies:
+    "@apollo/usage-reporting-protobuf" "^4.1.0"
+    "@apollo/utils.dropunuseddefinitions" "^2.0.1"
+    "@apollo/utils.printwithreducedwhitespace" "^2.0.1"
+    "@apollo/utils.removealiases" "2.0.1"
+    "@apollo/utils.sortast" "^2.0.1"
+    "@apollo/utils.stripsensitiveliterals" "^2.0.1"
+
+"@apollo/utils.withrequired@^2.0.0":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@apollo/utils.withrequired/-/utils.withrequired-2.0.1.tgz#e72bc512582a6f26af150439f7eb7473b46ba874"
+  integrity sha512-YBDiuAX9i1lLc6GeTy1m7DGLFn/gMnvXqlalOIMjM7DeOgIacEjjfwPqb0M1CQ2v11HhR15d1NmxJoRCfrNqcA==
+
 "@babel/code-frame@7.12.11":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.11.tgz#f4ad435aa263db935b8f10f2c552d23fb716a63f"
@@ -164,6 +338,37 @@
   resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-8.0.2.tgz#bab698c5d3da9c52744e966e0e3eedb6c8b05c37"
   integrity sha512-Uo3pGspElQW91PCvKSIAXoEgAUlRnH29sX2/p89kg7sP1m2PzCufHINd0FhTXQf6DYGiUlVncdSPa2F9wxed2A==
 
+"@graphql-tools/merge@^8.4.1":
+  version "8.4.2"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-8.4.2.tgz#95778bbe26b635e8d2f60ce9856b388f11fe8288"
+  integrity sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw==
+  dependencies:
+    "@graphql-tools/utils" "^9.2.1"
+    tslib "^2.4.0"
+
+"@graphql-tools/schema@^9.0.0":
+  version "9.0.19"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-9.0.19.tgz#c4ad373b5e1b8a0cf365163435b7d236ebdd06e7"
+  integrity sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w==
+  dependencies:
+    "@graphql-tools/merge" "^8.4.1"
+    "@graphql-tools/utils" "^9.2.1"
+    tslib "^2.4.0"
+    value-or-promise "^1.0.12"
+
+"@graphql-tools/utils@^9.2.1":
+  version "9.2.1"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-9.2.1.tgz#1b3df0ef166cfa3eae706e3518b17d5922721c57"
+  integrity sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    tslib "^2.4.0"
+
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@humanwhocodes/config-array@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.5.0.tgz#1407967d4c6eecd7388f83acf1eaf4d0c6e58ef9"
@@ -177,6 +382,11 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
+
+"@josephg/resolvable@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@josephg/resolvable/-/resolvable-1.0.1.tgz#69bc4db754d79e1a2f17a650d3466e038d94a5eb"
+  integrity sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==
 
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.3"
@@ -296,6 +506,59 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
+
+"@protobufjs/base64@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/base64/-/base64-1.1.2.tgz#4c85730e59b9a1f1f349047dbf24296034bb2735"
+  integrity sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==
+
+"@protobufjs/codegen@^2.0.4":
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@protobufjs/codegen/-/codegen-2.0.4.tgz#7ef37f0d010fb028ad1ad59722e506d9262815cb"
+  integrity sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==
+
+"@protobufjs/eventemitter@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
+  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
+
+"@protobufjs/fetch@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
+  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
+  dependencies:
+    "@protobufjs/aspromise" "^1.1.1"
+    "@protobufjs/inquire" "^1.1.0"
+
+"@protobufjs/float@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
+
+"@protobufjs/inquire@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
+  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
+
+"@protobufjs/path@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
+
+"@protobufjs/pool@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
+
+"@protobufjs/utf8@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
+  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
+
 "@radix-ui/react-compose-refs@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz#7ed868b66946aa6030e580b1ffca386dd4d21989"
@@ -387,6 +650,16 @@
   dependencies:
     "@types/node" "*"
 
+"@types/express-serve-static-core@^4.17.30":
+  version "4.17.36"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.36.tgz#baa9022119bdc05a4adfe740ffc97b5f9360e545"
+  integrity sha512-zbivROJ0ZqLAtMzgzIUC4oNqDG9iF0lSsAqpOD9kbs5xcIM3dTiyuHvBc7R8MtWBp3AAWGaovJa+wzWPjLYW7Q==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
 "@types/express-serve-static-core@^4.17.33":
   version "4.17.35"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.35.tgz#c95dd4424f0d32e525d23812aa8ab8e4d3906c4f"
@@ -397,7 +670,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@^4.17.17":
+"@types/express@^4.17.13", "@types/express@^4.17.17":
   version "4.17.17"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.17.tgz#01d5437f6ef9cfa8668e616e13c2f2ac9a491ae4"
   integrity sha512-Q4FmmuLGBG58btUnfS1c1r/NQdlp3DMfGDGig8WhfpA2YRUtEkxAjkZb0yvplJGYdF1fsQ81iMDcH24sSCNC/Q==
@@ -433,6 +706,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
+"@types/long@^4.0.0":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
+
 "@types/mime@*":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
@@ -455,6 +733,14 @@
   dependencies:
     mongoose "*"
 
+"@types/node-fetch@^2.6.1":
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.4.tgz#1bc3a26de814f6bf466b25aeb1473fa1afe6a660"
+  integrity sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==
+  dependencies:
+    "@types/node" "*"
+    form-data "^3.0.0"
+
 "@types/node@*":
   version "20.5.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.1.tgz#178d58ee7e4834152b0e8b4d30cbfab578b9bb30"
@@ -464,6 +750,11 @@
   version "17.0.45"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.45.tgz#2c0fafd78705e7a18b7906b5201a522719dc5190"
   integrity sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==
+
+"@types/node@^20.5.4":
+  version "20.5.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.5.4.tgz#4666fb40f9974d60c53c4ff554315860ba4feab8"
+  integrity sha512-Y9vbIAoM31djQZrPYjpTLo0XlaSwOIsrlfE3LpulZeRblttsLQRFRlBAppW0LOxyT3ALj2M5vU1ucQQayQH3jA==
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -582,6 +873,27 @@
   dependencies:
     "@typescript-eslint/types" "6.4.0"
     eslint-visitor-keys "^3.4.1"
+
+"@wry/context@^0.7.0", "@wry/context@^0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.7.3.tgz#240f6dfd4db5ef54f81f6597f6714e58d4f476a1"
+  integrity sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.6":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.6.tgz#cd4a533c72c3752993ab8cbf682d3d20e3cb601e"
+  integrity sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.4.3.tgz#077d52c22365871bf3ffcbab8e95cb8bc5689af4"
+  integrity sha512-I6bHwH0fSf6RqQcnnXLJKhkSXG45MFral3GxPaY4uAl0LYDZM+YDVDAiU9bYwjTuysy1S0IeecWtmq1SZA3M1w==
+  dependencies:
+    tslib "^2.3.0"
 
 abbrev@1:
   version "1.1.1"
@@ -819,6 +1131,13 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+async-retry@^1.2.1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
+
 asynciterator.prototype@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz#8c5df0514936cdd133604dfcc9d3fb93f09b2b62"
@@ -925,6 +1244,24 @@ body-parser@1.20.1:
     on-finished "2.4.1"
     qs "6.11.0"
     raw-body "2.5.1"
+    type-is "~1.6.18"
+    unpipe "1.0.0"
+
+body-parser@^1.20.0:
+  version "1.20.2"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.20.2.tgz#6feb0e21c4724d06de7ff38da36dad4f57a747fd"
+  integrity sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==
+  dependencies:
+    bytes "3.1.2"
+    content-type "~1.0.5"
+    debug "2.6.9"
+    depd "2.0.0"
+    destroy "1.2.0"
+    http-errors "2.0.0"
+    iconv-lite "0.4.24"
+    on-finished "2.4.1"
+    qs "6.11.0"
+    raw-body "2.5.2"
     type-is "~1.6.18"
     unpipe "1.0.0"
 
@@ -1194,7 +1531,7 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@^1.0.4, content-type@~1.0.4:
+content-type@^1.0.4, content-type@~1.0.4, content-type@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -1208,6 +1545,13 @@ cookie@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
+
+copy-anything@^3.0.2:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/copy-anything/-/copy-anything-3.0.5.tgz#2d92dce8c498f790fa7ad16b01a1ae5a45b020a0"
+  integrity sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==
+  dependencies:
+    is-what "^4.1.8"
 
 core-js-pure@^3.30.2:
   version "3.32.1"
@@ -1854,7 +2198,7 @@ express-graphql@^0.12.0:
     http-errors "1.8.0"
     raw-body "^2.4.1"
 
-express@^4.18.2:
+express@^4.17.1, express@^4.18.2:
   version "4.18.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.18.2.tgz#3fabe08296e930c796c19e3c516979386ba9fd59"
   integrity sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==
@@ -1992,6 +2336,15 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
+form-data@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
+  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
 form-data@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
@@ -2038,6 +2391,11 @@ fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+fs@^0.0.1-security:
+  version "0.0.1-security"
+  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
+  integrity sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==
 
 fsevents@~2.3.2:
   version "2.3.2"
@@ -2216,6 +2574,13 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
+graphql-tag@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
 graphql@^16.8.0:
   version "16.8.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.8.0.tgz#374478b7f27b2dc6153c8f42c1b80157f79d79d4"
@@ -2286,6 +2651,13 @@ header-case@^1.0.0:
   dependencies:
     no-case "^2.2.0"
     upper-case "^1.1.3"
+
+hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 http-errors@1.8.0:
   version "1.8.0"
@@ -2378,7 +2750,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -2664,6 +3036,11 @@ is-weakset@^2.0.1:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
+is-what@^4.1.8:
+  version "4.1.15"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-4.1.15.tgz#de43a81090417a425942d67b1ae86e7fae2eee0e"
+  integrity sha512-uKua1wfy3Yt+YqsD6mTUEa2zSi3G1oPlqTflgaPJ7z63vUGN5pxFpnQfeSLMFnJDEsdvOtkp1rUWkYjB4YfhgA==
+
 isarray@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
@@ -2806,6 +3183,11 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
+lodash.sortby@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
+  integrity sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==
+
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
@@ -2823,6 +3205,16 @@ log-symbols@^4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+loglevel@^1.6.8:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
+  integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==
+
+long@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/long/-/long-4.0.0.tgz#9a7b71cfb7d361a194ea555241c92f7468d5bf28"
+  integrity sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -2850,7 +3242,7 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
-lru-cache@^7.14.1:
+lru-cache@^7.10.1, lru-cache@^7.14.1:
   version "7.18.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
   integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
@@ -3029,7 +3421,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-negotiator@0.6.3:
+negotiator@0.6.3, negotiator@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
   integrity sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==
@@ -3074,6 +3466,18 @@ no-case@^2.2.0, no-case@^2.3.2:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-abort-controller@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/node-abort-controller/-/node-abort-controller-3.1.1.tgz#a94377e964a9a37ac3976d848cb5c765833b8548"
+  integrity sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==
+
+node-fetch@^2.6.7:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-plop@^0.26.3:
   version "0.26.3"
@@ -3225,6 +3629,15 @@ onetime@^5.1.0:
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
+
+optimism@^0.17.5:
+  version "0.17.5"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.17.5.tgz#a4c78b3ad12c58623abedbebb4f2f2c19b8e8816"
+  integrity sha512-TEcp8ZwK1RczmvMnvktxHSF2tKgMWjJ71xEFGX5ApLh67VsMSTy1ZUlipJw8W+KaqgOmQ+4pqwkeivY89j+4Vw==
+  dependencies:
+    "@wry/context" "^0.7.0"
+    "@wry/trie" "^0.4.3"
+    tslib "^2.3.0"
 
 optionator@^0.9.1:
   version "0.9.3"
@@ -3517,7 +3930,7 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-raw-body@^2.4.1:
+raw-body@2.5.2, raw-body@^2.4.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.5.2.tgz#99febd83b90e08975087e8f1f9419a149366b68a"
   integrity sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==
@@ -3545,7 +3958,7 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -3667,6 +4080,11 @@ resolve@^2.0.0-next.3, resolve@^2.0.0-next.4:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+response-iterator@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/response-iterator/-/response-iterator-0.2.6.tgz#249005fb14d2e4eeb478a3f735a28fd8b4c9f3da"
+  integrity sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==
+
 restore-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
@@ -3674,6 +4092,11 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"
@@ -3809,6 +4232,14 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.2.0.tgz#66c9a24a73f9fc28cbe66b09fed3d33dcaf1b424"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
+
+sha.js@^2.4.11:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.11.tgz#37a5cf0b81ecbc6943de109ba2960d1b26584ae7"
+  integrity sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -4027,6 +4458,13 @@ sucrase@^3.32.0:
     pirates "^4.0.1"
     ts-interface-checker "^0.1.9"
 
+superjson@^1.12.2:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/superjson/-/superjson-1.13.1.tgz#a0b6ab5d22876f6207fcb9d08b0cb2acad8ee5cd"
+  integrity sha512-AVH2eknm9DEd3qvxM4Sq+LTCkSXE2ssfh1t11MHMXyYXFQyQ1HLgVvV+guLTsaQnJU3gnaVo34TohHPulY/wLg==
+  dependencies:
+    copy-anything "^3.0.2"
+
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -4053,6 +4491,11 @@ swap-case@^1.1.0:
   dependencies:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
+
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
 
 table@^6.0.9:
   version "6.8.1"
@@ -4183,6 +4626,11 @@ tr46@^3.0.0:
   dependencies:
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 ts-api-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.0.2.tgz#7c094f753b6705ee4faee25c3c684ade52d66d99"
@@ -4192,6 +4640,13 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz#784fd3d679722bc103b1b4b8030bcddb5db2a699"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
 
 ts-node@^10.9.1:
   version "10.9.1"
@@ -4227,7 +4682,7 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.1, tslib@^2.1.0, tslib@^2.4.0:
+tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
@@ -4428,6 +4883,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
@@ -4444,6 +4904,11 @@ validate-npm-package-name@^5.0.0:
   integrity sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==
   dependencies:
     builtins "^5.0.0"
+
+value-or-promise@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
+  integrity sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==
 
 vary@^1, vary@~1.1.2:
   version "1.1.2"
@@ -4465,10 +4930,20 @@ wcwidth@^1.0.1:
   dependencies:
     defaults "^1.0.3"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
 webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
+
+whatwg-mimetype@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
+  integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
 
 whatwg-url@^11.0.0:
   version "11.0.0"
@@ -4477,6 +4952,14 @@ whatwg-url@^11.0.0:
   dependencies:
     tr46 "^3.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"
@@ -4568,6 +5051,18 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==
 
 zod@3.21.4:
   version "3.21.4"


### PR DESCRIPTION
This is a basic setup of Apollo Client for both server and client. 
To play with it you'd need to change the graphql url (in .env) to use port 4000 instead of 8080/graphql
In the browser you can also open localhost:4000 to see the Graphql Playground

In the client folder you'll find two new components - apollo-wrapper.js and client.js. 
Apollo-wrapper is used in the root Layout and doesn need to be used again. With this we can use 'useQuery()' **in the client components** of Next.
To use apollo client **in the server component,** you should import getClient and create const client = getClient(). Then you can use client.query() just as you would use useQuery.



