### PR TITLE
fixed the issue to go login page when there is no user stored in cookies

### DIFF
--- a/apps/client/app/page.tsx
+++ b/apps/client/app/page.tsx
@@ -1,19 +1,20 @@
-
+import { cookies } from 'next/headers'
 import { Button } from '@/components/ui/button';
 import '@/app/global.css'
 import Link from 'next/link';
 
 export default function Page() {
+  const cookieStore = cookies()
+  const loggedUserFullName = cookieStore.get('user').value
   return (
     <div className='flex flex-col items-center h-screen gap-10 justify-center'>
       <h2 className='text-3xl font-bold bg-pink-400 text-center'>WELCOME TO 360 REVIEW </h2>
-      <Link href={'/dashboard'}>
+      <Link href={loggedUserFullName ? '/dashboard' : '/login'}>
         <Button>Go to dashboard</Button>
       </Link>
       <Link href={'/managerpanel'}>
         <Button>Go to managerpanel</Button>
       </Link>
-
     </div>
   );
 }


### PR DESCRIPTION
It was erroring out when you try to go to /dashboard if there was no user saved in the cookies. Now it checks if the user exists in the cookies and goes to /login if there is no user.