### PR TITLE
FIS-147 feat(seeder): users have a consistent ID

### DIFF
--- a/apps/server/src/lib/mongoose/seeders/generate-id.ts
+++ b/apps/server/src/lib/mongoose/seeders/generate-id.ts
@@ -1,0 +1,19 @@
+import { Types } from 'mongoose'
+
+const { ObjectId } = Types
+
+function idGeneratorGenerator() {
+  let idDecimal = 0
+
+  return () => {
+    idDecimal++
+    const hex = idDecimal.toString(16)
+    const hex24char = hex.padStart(24, '0')
+    const id = new ObjectId(hex24char)
+    return id
+  }
+}
+
+const generateMongoId = idGeneratorGenerator()
+
+export default generateMongoId

--- a/apps/server/src/lib/mongoose/seeders/generate-users.ts
+++ b/apps/server/src/lib/mongoose/seeders/generate-users.ts
@@ -1,5 +1,7 @@
 import faker from './faker'
 import { modelTypes } from '@/fistbump-types'
+import generateMongoId from './generate-id'
+import { Types } from 'mongoose'
 
 const PASSWORD = '321'
 
@@ -35,7 +37,9 @@ export function generateSpecificUserModel(
   teamName: string,
   companyName: string
 ) {
-  const user: modelTypes.UserModel = {
+  const user: modelTypes.UserModel & { _id: Types.ObjectId } = {
+    // this generates consistent IDs that won't change every time we seed
+    _id: generateMongoId(),
     email: `${firstName.toLowerCase()}@${companyName.toLowerCase()}`,
     fullName: `${firstName} ${lastName}`,
     hashedPw: PASSWORD,

--- a/apps/server/src/lib/mongoose/seeders/seeder-aroldev.ts
+++ b/apps/server/src/lib/mongoose/seeders/seeder-aroldev.ts
@@ -54,8 +54,6 @@ async function seedArolDevData() {
     console.log(`${users.length} users have been added to the database`)
     console.log(users)
 
-    users.forEach((user) => (user._id = generateMongoId()))
-
     const arol = users.find((user) => {
       return user.title === 'CTO'
     })

--- a/apps/server/src/lib/mongoose/seeders/seeder-aroldev.ts
+++ b/apps/server/src/lib/mongoose/seeders/seeder-aroldev.ts
@@ -11,6 +11,7 @@ import { ObjectId } from './types'
 import mongoose from 'mongoose'
 import 'dotenv/config'
 import { addDays } from '../../utils'
+import generateMongoId from './generate-id'
 
 // CYCLE CONFIG
 const yesterday = addDays(new Date(), -1)
@@ -52,6 +53,8 @@ async function seedArolDevData() {
     if (!users) throw new Error('User.insertMany() failed')
     console.log(`${users.length} users have been added to the database`)
     console.log(users)
+
+    users.forEach((user) => (user._id = generateMongoId()))
 
     const arol = users.find((user) => {
       return user.title === 'CTO'


### PR DESCRIPTION
This is so you can use the same token after a re-seed