### PR TITLE
Apollo with default options is not using cache

### DIFF
--- a/apps/client/lib/apollo-client.js
+++ b/apps/client/lib/apollo-client.js
@@ -36,11 +36,25 @@ const authLink = setContext((_, { headers }) => {
     },
   }
 })
+
+// ? options no to cache
+const defaultOptions = {
+  watchQuery: {
+    fetchPolicy: 'no-cache',
+    errorPolicy: 'ignore',
+  },
+  query: {
+    fetchPolicy: 'no-cache',
+    errorPolicy: 'all',
+  },
+}
+
 const { getClient } = registerApolloClient(() => {
   const removeTypenameLink = removeTypenameFromVariables()
   return new NextSSRApolloClient({
     cache: new NextSSRInMemoryCache(options),
     link: authLink.concat(httpLink),
+    defaultOptions: defaultOptions,
   })
 })
 


### PR DESCRIPTION
In this configuration, the fetchPolicy 'no-cache' ensures that Apollo Client does not use the cache for any query. Instead, it always sends a network request to fetch data and does not cache the response. This guarantees that your components always display the most current data from your server : https://stackoverflow.com/questions/47879016/how-to-disable-cache-in-apollo-link-or-apollo-client#:~:text=If%20you%20really%20want%20to,not%20stored%20in%20the%20cache.%22

Keep in mind that disabling the cache globally may increase the load on your server and slow down your application because every query triggers a network request. In most cases, it's better to disable the cache only for specific queries that need real-time data.

https://medium.com/rbi-tech/tips-and-tricks-for-working-with-apollo-cache-3b5a757f10a0