### PR TITLE
Feat kill used ports

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "private": true,
   "scripts": {
     "build": "turbo run build",
+    "predev": "./prestart.sh",
     "dev": "turbo run dev & docker-compose up",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/prestart.sh
+++ b/prestart.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Check and kill processes on port 4000
+PORT=4000
+lsof -i :$PORT | awk 'NR!=1 {print $2}' | xargs -I {} kill -9 {}
+
+# Check and kill processes on port 3000
+PORT=3000
+lsof -i :$PORT | awk 'NR!=1 {print $2}' | xargs -I {} kill -9 {}

--- a/prestart.sh
+++ b/prestart.sh
@@ -4,6 +4,8 @@
 PORT=4000
 lsof -i :$PORT | awk 'NR!=1 {print $2}' | xargs -I {} kill -9 {}
 
+
+
 # Check and kill processes on port 3000
 PORT=3000
 lsof -i :$PORT | awk 'NR!=1 {print $2}' | xargs -I {} kill -9 {}


### PR DESCRIPTION
guys this is a little tweak when we start YARN DEV it does predev and runs prestart.sh

which is a file that checks if theres any used ports and kills them automatically. so you dont have to lsof

when you are testing it, run 

chmod +x prestart.sh

this in your terminal, its basicaly allowing this script to run.

happy coding!